### PR TITLE
Add concept of a default user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ entry:
 issuer = https://scitokens.org/osg-connect
 base_path = /stash
 map_subject = True
+default_user = osg
 ```
 
 Each section name specifying a new issuer *MUST* be prefixed with `Issuer`.  Known attributes
@@ -53,3 +54,6 @@ are:
       into the Xrootd username.  When combined with the [xrootd-multiuser](https://github.com/bbockelm/xrootd-multiuser)
       plugin, this will allow the Xrootd daemon to write out files utilizing the Unix username specified by the VO
       in the token.  Except in narrow use cases, the default of `false` is sufficient.
+   - `default_user` (optional): If set, then all authorized operations will be done under the provided username when
+      interacting with the filesystem.  This is useful in the case where the administrator desires that all files owned
+      by an issuer should be mapped to a particular Unix user account at the site.

--- a/src/scitokens_xrootd.py
+++ b/src/scitokens_xrootd.py
@@ -104,6 +104,8 @@ def config(fname):
         issuer_info['base_path'] = base_path
         if 'map_subject' in cp.options(section):
             issuer_info['map_subject'] = cp.getboolean(section, 'map_subject')
+        if 'default_user' in cp.options(section):
+            issuer_info['default_user'] = cp.get(section, 'default_user')
         print "Configured token access for %s (issuer %s): %s" % (section, issuer, str(issuer_info))
 
 def init(parms=None):
@@ -171,4 +173,8 @@ def generate_acls(header):
     subject = ""
     if g_authorized_issuers[issuer].get('map_subject') and ('sub' in claims):
         subject = claims['sub']
+    else:
+        default_user = g_authorized_issuers[issuer].get('default_user')
+        if default_user:
+            subject = default_user
     return int(cache_expiry), acls, str(subject)


### PR DESCRIPTION
When using SciTokens with xrootd-hdfs, most filesystem operations will
be performed utilizing the `nobody` user, which may mess up permissions
when accessing HDFS from non-Xrootd-based mechanisms.

With this change, xrootd-scitokens will set a default username that the
filesystem plugin would be able to utilize when interacting with the
storage.  The `default_user` parameter in the issuer section does not
affect mapping decisions.