### PR TITLE
Switch vectors from reserve() to resize()

### DIFF
--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -611,7 +611,7 @@ private:
         try {
             m_audiences = std::move(audiences);
             size_t idx = 0;
-            m_audiences_array.reserve(m_audiences.size() + 1);
+            m_audiences_array.resize(m_audiences.size() + 1);
             for (const auto &audience : m_audiences) {
                 m_audiences_array[idx++] = audience.c_str();
             }
@@ -620,7 +620,7 @@ private:
             m_issuers = std::move(issuers);
             m_valid_issuers.clear();
             m_valid_issuers.reserve(m_issuers.size());
-            m_valid_issuers_array.reserve(m_issuers.size() + 1);
+            m_valid_issuers_array.resize(m_issuers.size() + 1);
             idx = 0;
             for (const auto &issuer : m_valid_issuers) {
                 m_valid_issuers_array[idx++] = issuer.c_str();


### PR DESCRIPTION
Compiler flags from EL8 packaging uncover an assertion failure

<details>
<summary>Logs</summary>

```
200805 17:30:12 733 scitokens_Reconfig: Parsing configuration file: /run/stash-cache-auth/scitokens.conf
/usr/include/c++/8/bits/stl_vector.h:932: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = const char*; _Alloc = std::allocator<const char*>; std::vector<_Tp, _Alloc>::reference = const char*&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed.
==733==
==733== Process terminating with default action of signal 6 (SIGABRT): dumping core
==733==    at 0x635670F: raise (in /usr/lib64/libc-2.28.so)
==733==    by 0x6340B24: abort (in /usr/lib64/libc-2.28.so)
==733==    by 0x10C642E7: std::__replacement_assert(char const*, int, char const*, char const*) (c++config.h:2391)
==733==    by 0x10C64572: std::vector<char const*, std::allocator<char const*> >::operator[](unsigned long) (stl_vector.h:932)
==733==    by 0x10C6DB58: XrdAccSciTokens::Reconfig() (scitokens.cpp:618)
==733==    by 0x10C63F87: XrdAccSciTokens (scitokens.cpp:228)
==733==    by 0x10C63F87: XrdAccAuthorizeObject (scitokens.cpp:678)
==733==    by 0x4EB265B: XrdOfsConfigPI::SetupAuth() (XrdOfsConfigPI.cc:574)
==733==    by 0x4EB2B3F: XrdOfsConfigPI::Load(int, XrdOfs*, XrdOucEnv*) (XrdOfsConfigPI.cc:219)
==733==    by 0x4EB0A8B: XrdOfs::Configure(XrdSysError&, XrdOucEnv*) (XrdOfsConfig.cc:275)
==733==    by 0x4EAC8D3: XrdSfsGetDefaultFileSystem(XrdSfsFileSystem*, XrdSysLogger*, char const*, XrdOucEnv*) (XrdOfsFS.cc:69)
==733==    by 0x4E86B5C: XrdXrootdProtocol::Configure(char*, XrdProtocol_Config*) (XrdXrootdConfig.cc:282)
==733==    by 0x4E8FA02: XrdgetProtocol (XrdXrootdProtocol.cc:165)
```
</details>