### PR TITLE
Add ability to provide an alternate JSON mapfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ It must parse as valid JSON and may look like this:
 
 [
    {"sub": "bbockelm",    "path": "/home/bbockelm", "result": "bbockelm"},
-   {"group": "/cms/prod", "path": "/cms",           "result": "cmsprod"},
-   {"group": "/cms",                                "result": "cmsuser"}
+   {"group": "/cms/prod", "path": "/cms",           "result": "cmsprod" comment="Added 1 Sept 2020"},
+   {"group": "/cms",                                "result": "cmsuser"},
+   {"group": "/cms",                                "result": "atlas"   ignore="Only for testing"}
 ]
 
 That is, we have a JSON list of objects; each object is interpreted as a rule.  For an incoming request to match a rule,
@@ -123,5 +124,7 @@ The enumerated keys are:
      the rule is `/bbockelm`, then this attribute evaluates to `true`.  Note the path value and the requested path must
      be normalized; if presented with `/home//bockelm/`, then this is treated as if `/home/bbockelm` was given.
    - `group`: Case-sensitive match against one of the groups in the token.
+   - `ignore`: If present (regardless of the value), the rule is ignored.
+   - `comment`: Ignored; reserved for adding comments from the administrator.
 
 Unknown keys are ignored.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ issuer = https://scitokens.org/osg-connect
 base_path = /stash
 map_subject = True
 default_user = osg
+name_mapfile = /path/to/mapfile
 ```
 
 Within the `Global` section, the available attributes are:
@@ -56,13 +57,25 @@ Within the `Global` section, the available attributes are:
      that exactly matches this value
    - `audience_json` (optional): JSON string or list specifying the acceptable audiences.  This audience option will allow
      commas and spaces within the audience.  `audience_json` takes precedence over `audience`.
+   - `onmissing` (optional): The behavior for the plugin when a token is not present or the token does not authorize
+     the requested action.  Valid values are:
+
+        - `passthrough`: Invoke the next configured authorization plugin.
+        - `allow`: Immediately authorize the request.  This may be useful when the XRootD authorization is supposed to
+          always succeed because authorization is implemented in the filesystem (note this plugin may still update
+          the internal credential with useful information for the filesystem to make a decision).
+        - `deny`: Immediately deny the request.
+
+     If the token is present and valid, then the internal XRootD credential will be populated with any present
+     group or issuer information from the token.  The username is only populated if either scope-based mapping or
+     the mapfile-based approach is successful.
 
 Each section name specifying a new issuer *MUST* be prefixed with `Issuer`.  Known attributes
 are:
 
    - `issuer` (required): The URI of the token issuer; this must match the value of the corresponding claim int
       the token.
-   - `base_path` (required): The path any token authorizations are relative to.
+   - `base_path` (required): The paths any token authorizations are relative to; a comma-separated list is permitted.
    - `restricted_path` (optional): Any restrictions on the paths the issuer can authorize *inside* their namespace.  This
       meant to be a mechanism to help with transitions, where the local site storage is setup such that an issuer's
       namespace contains directories that should not be managed by the issuer.
@@ -73,3 +86,42 @@ are:
    - `default_user` (optional): If set, then all authorized operations will be done under the provided username when
       interacting with the filesystem.  This is useful in the case where the administrator desires that all files owned
       by an issuer should be mapped to a particular Unix user account at the site.
+   -  `name_mapfile` (options): If set, then the referenced file is parsed as a JSON object and the specified mappings
+      are applied to the username inside the XRootD framework.  See below for more information on the mapfile.
+
+Group- and Scope-based authorization
+------------------------------------
+
+WLCG tokens can contain either group- or scope-based attributes.  The scope-based attributes specify a path the user
+is allowed to access (relative to one of the base paths).  If a request is permitted via a scope-based attribute, then
+it is approved immediately by the plugin.
+
+If there is a group-based attribute, then the contents are copied into XRootD's internal credential.  The plugin does
+not necessarily immediately authorize (see the `onmissing` attribute) but rather can be used by a further authorization
+plugin.
+
+Mapfile format
+--------------
+
+The file specified by the `name_mapfile` attribute can be used to perform identity mapping for a given issuer.
+It must parse as valid JSON and may look like this:
+
+[
+   {"sub": "bbockelm",    "path": "/home/bbockelm", "result": "bbockelm"},
+   {"group": "/cms/prod", "path": "/cms",           "result": "cmsprod"},
+   {"group": "/cms",                                "result": "cmsuser"}
+]
+
+That is, we have a JSON list of objects; each object is interpreted as a rule.  For an incoming request to match a rule,
+each present attribute must evaluate to true.  In this case, the value of the `result` key is populated as the username
+in the XRootD internal credential.
+
+The enumerated keys are:
+   - `sub`: True if the `sub` claim in the token matches the value in the mapfile (case-sensitive comparison).
+   - `path`: True iff the value of the attribute matches (case-sensitive) the prefix of the (normalized) requested path.
+     For example, if the issuer's base path is `/home`, the operation is accessing `/home/bbockelm/foo`, and the path in
+     the rule is `/bbockelm`, then this attribute evaluates to `true`.  Note the path value and the requested path must
+     be normalized; if presented with `/home//bockelm/`, then this is treated as if `/home/bbockelm` was given.
+   - `group`: Case-sensitive match against one of the groups in the token.
+
+Unknown keys are ignored.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The enumerated keys are:
    - `path`: True iff the value of the attribute matches (case-sensitive) the prefix of the (normalized) requested path.
      For example, if the issuer's base path is `/home`, the operation is accessing `/home/bbockelm/foo`, and the path in
      the rule is `/bbockelm`, then this attribute evaluates to `true`.  Note the path value and the requested path must
-     be normalized; if presented with `/home//bockelm/`, then this is treated as if `/home/bbockelm` was given.
+     be normalized; if presented with `/home//bbockelm/`, then this is treated as if `/home/bbockelm` was given.
    - `group`: Case-sensitive match against one of the groups in the token.
    - `ignore`: If present (regardless of the value), the rule is ignored.
    - `comment`: Ignored; reserved for adding comments from the administrator.

--- a/rpm/xrootd-scitokens.spec
+++ b/rpm/xrootd-scitokens.spec
@@ -1,5 +1,5 @@
 Name: xrootd-scitokens
-Version: 1.2.2
+Version: 1.3.0
 Release: 1%{?dist}
 Summary: SciTokens authentication plugin for XRootD
 License: Apache 2.0
@@ -59,6 +59,9 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 
 %changelog
+* Sat Sep 19 2020 Brian Bockelman <brian.bockelman@cern.ch> - 1.3.0-1
+- Allow administrator to provide mapfiles for establishing the username.
+
 * Wed Aug 06 2020 Derek Weitzel <dweitzel@cse.unl.edu> - 1.2.2-1
 - Fix behavior difference between el7 and el8 #30
 - Set allowed_issuers in the JWT deserialize #31

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -160,8 +160,6 @@ struct MapRule
     {
         if (!m_sub.empty() && sub != m_sub) {return "";}
 
-        //std::cerr << "Comparing requested path " << req_path << " against registered path preffix " << m_path_prefix << std::endl;
-
         if (!m_path_prefix.empty() &&
             strncmp(req_path.c_str(), m_path_prefix.c_str(), m_path_prefix.size()))
         {
@@ -643,6 +641,7 @@ private:
             std::string group;
             std::string sub;
             std::string result;
+            bool ignore = false;
             for (const auto &entry : rule.get<picojson::object>()) {
                 if (!entry.second.is<std::string>()) {
                     if (entry.first != "result" && entry.first != "group" && entry.first != "sub" && entry.first != "path") {continue;}
@@ -668,8 +667,12 @@ private:
                         return false;
                     }
                     path = norm_path;
+                } else if (entry.first == "ignore") {
+                    ignore = true;
+                    break;
                 }
             }
+            if (ignore) continue;
             if (result.empty())
             {
                 ss << "In mapfile " << filename << " encountered a rule without a 'result' attribute";

--- a/test/test_inside_docker.sh
+++ b/test/test_inside_docker.sh
@@ -11,7 +11,7 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}
 
 yum -y install yum-plugin-priorities rpm-build gcc gcc-c++ boost-devel boost-python cmake git tar gzip make autotools python-devel
 
-rpm -Uvh https://repo.opensciencegrid.org/osg/3.4/osg-3.4-el${OS_VERSION}-release-latest.rpm
+rpm -Uvh https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el${OS_VERSION}-release-latest.rpm
 
 yum -y install xrootd-server-devel
 yum -y install --enablerepo=osg-development scitokens-cpp-devel


### PR DESCRIPTION
This PR provides three key new features:

1.  Adds a new JSON mapfile allowing more fine-grained control of the returned user attribute.
2. Does not always add the default username to the `XrdSecEntity` - this is only done if the scope-based authorization is successful.
3. Extracts groups from the token's `wlcg.groups` attribute.

Note the second is a significant change for cases where tokens are chained against an `Authfile`.  The prior behavior often had the side-effect of giving VO-level authorization to any token if the `Authfile`  had broad permissions for that user.